### PR TITLE
Help text references to old? name of this script?

### DIFF
--- a/src/installation/InstallSecurityAgent.sh
+++ b/src/installation/InstallSecurityAgent.sh
@@ -20,7 +20,7 @@ _hostName=
 
 usage()
 {
-    echo "usage: InstallAgent [[-aui <authentication identity> ] [[-aum <authentication method> ] [[-f <file path> ] [[-hn <host name> ] [[-di <device id> ] [-i | -u] | [-h]]"
+    echo "usage: InstallSecurityAgent [[-aui <authentication identity> ] [[-aum <authentication method> ] [[-f <file path> ] [[-hn <host name> ] [[-di <device id> ] [-i | -u] | [-h]]"
 }
 
 wgetAndExitOnFail(){


### PR DESCRIPTION
The help text of "InstallSecurityAgent.sh" now begins with 'InstallSecurityAgent'