### PR TITLE
Add default LocalConfigurationFile + make service file as link

### DIFF
--- a/src/installation/InstallSecurityAgent.sh
+++ b/src/installation/InstallSecurityAgent.sh
@@ -143,7 +143,7 @@ installagent()
     sed -e "s|{DIRECTORY}|$_targetDirectory|g" -e "s|{EXE}|$_execName|g" -e "s|{USER}|$_userName|g" -e "s|{GROUP}|$_userName|g" $_serviceTemplateName > $_targetDirectory/$_serviceTemplateName
 
     #link the service file to the system service files location
-    ln -s $_systemServiceFileLocation/$_serviceTemplateName
+    ln -s $_targetDirectory/$_serviceTemplateName $_systemServiceFileLocation/$_serviceTemplateName 
 
     #reload the deamon, in case is was already installed before
     systemctl daemon-reload

--- a/src/installation/InstallSecurityAgent.sh
+++ b/src/installation/InstallSecurityAgent.sh
@@ -140,7 +140,10 @@ installagent()
     chmod +x $_targetDirectory/$_omsBaseline
 
     #replace variables in the service file template
-    sed -e "s|{DIRECTORY}|$_targetDirectory|g" -e "s|{EXE}|$_execName|g" -e "s|{USER}|$_userName|g" -e "s|{GROUP}|$_userName|g" $_serviceTemplateName > $_systemServiceFileLocation/$_serviceTemplateName
+    sed -e "s|{DIRECTORY}|$_targetDirectory|g" -e "s|{EXE}|$_execName|g" -e "s|{USER}|$_userName|g" -e "s|{GROUP}|$_userName|g" $_serviceTemplateName > $_targetDirectory/$_serviceTemplateName
+
+    #link the service file to the system service files location
+    ln -s $_systemServiceFileLocation/$_serviceTemplateName
 
     #reload the deamon, in case is was already installed before
     systemctl daemon-reload

--- a/src/installation/LocalConfiguration.json
+++ b/src/installation/LocalConfiguration.json
@@ -1,0 +1,9 @@
+{
+    "Authentication": {
+        "Identity": "",
+        "AuthenticationMethod": "",
+        "FilePath": "",
+        "DeviceId": "",
+        "HostName": ""
+    }
+}


### PR DESCRIPTION
Hi, 

Please find this contribution about the service installation. 
- Creates the default LocalConfiguration.json file in the installation directory (making this created by default while installing)
- Create a symlink of the service file fril the target directory to the service directory instead of having 2 files that doesn't have the same content (making confusing)

Regards, 